### PR TITLE
Add Eat the Rich Challenge mod

### DIFF
--- a/challengedata.lua
+++ b/challengedata.lua
@@ -56,7 +56,7 @@ ChallengeMod.ChallengeData =
     {
         Name = "Eat The Rich",
         Description = "At the end of every biome, lose max health based on how much money you have. ",
-        Author = "cgull",
+        Author = "colorsdontgo",
         SetupFunction = "EatTheRichSetup",
         HellMode=False,
         RestoreRoomData=true,

--- a/challengedata.lua
+++ b/challengedata.lua
@@ -50,6 +50,16 @@ ChallengeMod.ChallengeData =
         SetupFunction = "PomOneBoonSetup",
         HellMode=False,
         RestoreRoomData=true,
+    },
+
+    EatTheRich = 
+    {
+        Name = "Eat The Rich",
+        Description = "At the end of every biome, lose max health based on how much money you have. ",
+        Author = "cgull",
+        SetupFunction = "EatTheRichSetup",
+        HellMode=False,
+        RestoreRoomData=true,
     }
 
     -- BossRush =

--- a/challengescripts.lua
+++ b/challengescripts.lua
@@ -39,8 +39,8 @@ function EatTheRichSetup()
             -- More money, bigger percentage removed. Starting with calculating 5% of money to determine the percent removed.
             -- We also want to remove the same % from the amount of health we have, to make it spicy
             -- I have no idea if this will work.
-            CurrentRun.Hero.MaxHealth = CurrentRun.Hero.MaxHealth * (1.0- (CurrentRun.Money * 0.05)/100)
-            CurrentRun.Hero.Health = CurrentRun.Hero.Health * (1.0- (CurrentRun.Money * 0.05)/100)
+            CurrentRun.Hero.MaxHealth = CurrentRun.Hero.MaxHealth * (1.0 - (CurrentRun.Money * 0.05)/100)
+            CurrentRun.Hero.Health = CurrentRun.Hero.Health * (1.0 - (CurrentRun.Money * 0.05)/100)
         end
     end
 end

--- a/challengescripts.lua
+++ b/challengescripts.lua
@@ -32,6 +32,19 @@ function PomOneBoonSetup()
     end
 end
 
+function EatTheRichSetup()
+    for _, roomData in pairs(RoomData) do
+        if string.find(roomData.Name, "PostBoss") then
+            -- We basically use the amount of money to determine what percentage of our health we are taking away. 
+            -- More money, bigger percentage removed. Starting with calculating 5% of money to determine the percent removed.
+            -- We also want to remove the same % from the amount of health we have, to make it spicy
+            -- I have no idea if this will work.
+            CurrentRun.Hero.MaxHealth = CurrentRun.Hero.MaxHealth * (1.0- (CurrentRun.Money * 0.05)/100)
+            CurrentRun.Hero.Health = CurrentRun.Hero.Health * (1.0- (CurrentRun.Money * 0.05)/100)
+        end
+    end
+end
+
 ModUtil.Path.Wrap("IsRoomRewardEligible", function( baseFunc, run, room, reward, previouslyChosenRewards, args)
     if ChallengeMod.ActiveChallenge == ChallengeMod.ChallengeData.PomOneBoon.Name then
         local reward2 = DeepCopyTable(reward)

--- a/challengescripts.lua
+++ b/challengescripts.lua
@@ -64,6 +64,16 @@ function RemoveHealth( args )
     thread( UpdateHealthUI )
 end
 
+ModUtil.Path.Wrap("CalculateDamageAdditions", function(baseFunc, attacker, victim, triggerArgs)
+    if ChallengeMod.ActiveChallenge == ChallengeMod.ChallengeData.EatTheRich.Name then
+        local damageReduction = -0.05 * CurrentRun.Money
+        DebugPrint({Text="ChallengeMod: Reducing damage by "..damageReduction})
+        return baseFunc(attacker, victim, triggerArgs) + damageReduction
+    else
+        return baseFunc(attacker, victim, triggerArgs)
+    end
+end, ChallengeMod)
+
 ModUtil.Path.Wrap("IsRoomRewardEligible", function( baseFunc, run, room, reward, previouslyChosenRewards, args)
     if ChallengeMod.ActiveChallenge == ChallengeMod.ChallengeData.PomOneBoon.Name then
         local reward2 = DeepCopyTable(reward)


### PR DESCRIPTION
This mod reduces health and damage based on current money. It combines the concepts of two different traits Zag has and makes them hurt you.

First, it follows the example of Golden Touch (which increases money based on the current money at the end of the biome) and reduces health (max and current) by a percentage at the end of a biome. This health reduction is currently calculated as 5% of your current wealth, seen as a percentage. The richer you are, the more health you lose.

Second, it follows the example of Hoarding Slash, except instead of increasing your damage based on how much money, it reduces your damage based on your money. The richer you are, the less damage you do.

This mod essentially encourages you to spend as much money as you can, which ultimately should probably make you stronger, but a challenge runner could find a challenge in gathering as much money as they can to see how low they can reduce their health and/or damage.